### PR TITLE
update calendar setup: separating day of the week from date

### DIFF
--- a/_modules/week-01.md
+++ b/_modules/week-01.md
@@ -2,33 +2,33 @@
 title: Week 1
 topic: Representing data (Variables, Expressions, and Types)
 ---
-Monday - Jun 20
+Monday<br/>Jun 20
 : **Holiday (no classes)**{: .label .label-red }June 20 (Juneteenth)
 
 : [](#)
 
-Tuesday - Jun 21
+Tuesday<br/>Jun 21
 : <p class="text-grey-dk-000 mb-0"><em>Instruction Begins (Session A)</em></p>
 : **09:30am** **Class**{: .label .label-purple }
 : _Read the covered sections from zybook and solve the PAs and CAs for them_
 
-Wednesday - Jun 22
+Wednesday<br/>Jun 22
 : **09:30am** **Class**{: .label .label-purple }
 :  _Read the covered sections from zybook and solve the PAs and CAs for them_
 
-Thursday - Jun 23
+Thursday<br/>Jun 23
 : **09:30am** **Class**{: .label .label-purple }
 :  _Read the covered sections from zybook and solve the PAs and CAs for them_
 : _Start in checkpoint labs and the remaining of labs. Prepare your questions_
 
 
-Friday - Jun 24
+Friday<br/>Jun 24
 : **3:00pm to 9:00 pm** ⏰ Due: **QUIZ**{: .label .label-darkcyan }
 : **11:59PM** ⏰ Due: **Reflection**{: .label .label-yellow }
 
-Saturday - Jun 25
+Saturday<br/>Jun 25
 : _Read next week's chapter (chapter 1) and start in the PAs and CAs_
 
-Sunday - Jun 26
+Sunday<br/>Jun 26
 : _Continue reading the chapter and prepare your questions to ask them on_
 

--- a/_modules/week-02.md
+++ b/_modules/week-02.md
@@ -2,35 +2,35 @@
 title: Week 2
 topic: Functions and Modules
 ---
-Monday - Jun 27
+Monday<br/>Jun 27
 : **11:59PM** ⏰  Due: **PA02**{: .label .label-orange }
 : _Finish reading and review Chapter 02 in zyBooks._
 : _Complete the PAs and CAs._
 : _Test your understanding with the Reading Quiz._
 
-Tuesday - Jun 28
+Tuesday<br/>Jun 28
 : **09:30am** **Class**{: .label .label-purple }
 : **11:59PM** ⏰  Due: **CA02**{: .label .label-blue }
 : **11:59PM** ⏰  Due: **LA01**{: .label .label-green }
 
-Wednesday - Jun 29
+Wednesday<br/>Jun 29
 : **09:30am** **Class**{: .label .label-purple }
 : _Start working on the labs_
 
-Thursday - Jun 30
+Thursday<br/>Jun 30
 : **09:30am** **Class**{: .label .label-purple }
 : **11:59PM** ⏰  Due: **LA Checkpoint**{: .label .label-green }
 
-Friday - Jul 1
+Friday<br/>Jul 1
 : **3:00pm** to **9:00 pm** ⏰ Due: **QUIZ**{: .label .label-darkcyan }
 : **11:59PM** ⏰ Due: **Reflection**{: .label .label-yellow }
 : _Begin reading next week’s chapter._
 : _Work through its PAs and CAs._
 
-Saturday - Jul 2
+Saturday<br/>Jul 2
 : _Read next week's chapter (chapter 3) and start in the PAs and CAs_
 
-Sunday - Jul 3
+Sunday<br/>Jul 3
 : _By the end of Sunday: Ideally, you should be finished with PAs for Chapter 3 and done with the CAs for its first 4-5 sections._
 
 

--- a/_modules/week-03.md
+++ b/_modules/week-03.md
@@ -2,38 +2,38 @@
 title: Week 3
 topic: Making decisions in programs (Branching)
 ---
-Monday - Jul 4
+Monday<br/>Jul 4
 : **Holiday (no classes)**{: .label .label-red }July 4 (Independence Day)
 : **11:59PM** ⏰  Due: **PA03**{: .label .label-orange }
 : _Finish reading and review Chapter 03 in zyBooks._
 : _Complete the PAs and CAs._
 : _Test your understanding with the Reading Quiz._
 
-Tuesday - Jul 5
+Tuesday<br/>Jul 5
 : **09:30am** **Class**{: .label .label-purple }
 : **11:59PM** ⏰  Due: **CA03**{: .label .label-blue }
 : **11:59PM** ⏰  Due: **LA02**{: .label .label-green }
 
-Wednesday - Jul 6
+Wednesday<br/>Jul 6
 : **09:30am** **Class**{: .label .label-purple }
 : _Start working on the labs_
   
 
-Thursday - Jul 7
+Thursday<br/>Jul 7
 : <p class="text-grey-dk-000 mb-0"><em>Deadline to Drop Courses (Session A)</em></p>
 
 : **09:30am** **Class**{: .label .label-purple }
 : **11:59PM** ⏰  Due: **LA Checkpoint**{: .label .label-green }
 
 
-Friday - Jul 8
+Friday<br/>Jul 8
 : **3:00pm** to **9:00 pm** ⏰ Due: **QUIZ**{: .label .label-darkcyan }
 : **11:59PM** ⏰ Due: **Reflection**{: .label .label-yellow }
 : _Begin reading next week’s chapter._
 : _Work through its PAs and CAs._
 
-Saturday - Jul 9
+Saturday<br/>Jul 9
 : _Read next week's chapter (chapter 4) and start in the PAs and CAs_
 
-Sunday - Jul 10
+Sunday<br/>Jul 10
 : _By the end of Sunday: Ideally, you should be finished with PAs for Chapter 4 and done with the CAs for its first 4-5 sections._

--- a/_modules/week-04.md
+++ b/_modules/week-04.md
@@ -2,34 +2,34 @@
 title: Week 4
 topic: Repeating and iterating (Loops)
 ---
-Monday - Jul 11
+Monday<br/>Jul 11
 : **11:59PM** ⏰  Due: **PA04**{: .label .label-orange }
 : _Finish reading and review Chapter 04 in zyBooks._
 : _Complete the PAs and CAs._
 : _Test your understanding with the Reading Quiz._
 
-Tuesday - Jul 12
+Tuesday<br/>Jul 12
 : **09:30am** **Class**{: .label .label-purple }
 : **11:59PM** ⏰  Due: **CA04**{: .label .label-blue }
 : **11:59PM** ⏰  Due:**LA03**{: .label .label-green }
 
-Wednesday - Jul 13
+Wednesday<br/>Jul 13
 : **09:30am** **Class**{: .label .label-purple }
 : _Start working on the labs_
 
-Thursday - Jul 14
+Thursday<br/>Jul 14
 : **09:30am** **Class**{: .label .label-purple }
 : **11:59PM** ⏰  Due: **LA Checkpoint**{: .label .label-green }
 
-Friday - Jul 15
+Friday<br/>Jul 15
 : **3:00pm** to **9:00 pm** ⏰ Due: **QUIZ**{: .label .label-darkcyan }
 : **11:59PM** ⏰ Due: **Reflection**{: .label .label-yellow }
 : _Begin reading next week’s chapter._
 : _Work through its PAs and CAs._
 
-Saturday - Jul 16
+Saturday<br/>Jul 16
 : _Read next week's chapter (chapter 5) and start in the PAs and CAs_
 
-Sunday - Jul 17
+Sunday<br/>Jul 17
 : _By the end of Sunday: Ideally, you should be finished with PAs for Chapter 5 and done with the CAs for its first 4-5 sections._
 

--- a/_modules/week-05.md
+++ b/_modules/week-05.md
@@ -2,36 +2,36 @@
 title: Week 5
 topic: More on collections and Working with Files
 ---
-Monday - Jul 18
+Monday<br/>Jul 18
 : **11:59PM** ⏰  Due: **PA05**{: .label .label-orange }
 : _Finish reading and review Chapter 05 in zyBooks._
 : _Complete the PAs and CAs._
 : _Test your understanding with the Reading Quiz._
 
-Tuesday - Jul 19
+Tuesday<br/>Jul 19
 : **09:30am** **Class**{: .label .label-purple }
 : **11:59PM** ⏰  Due: **CA05**{: .label .label-blue }
 : **11:59PM** ⏰  Due: **LA04**{: .label .label-green }
 
-Wednesday - Jul 20
+Wednesday<br/>Jul 20
 : **09:30am** **Class**{: .label .label-purple }
 : _Start working on the labs_
 
 
-Thursday - Jul 21
+Thursday<br/>Jul 21
 : **09:30am** **Class**{: .label .label-purple }
 : **11:59PM** ⏰  Due: **LA Checkpoint**{: .label .label-green }
 
-Friday - Jul 22
+Friday<br/>Jul 22
 : **3:00pm** to **9:00 pm** ⏰ Due: **QUIZ**{: .label .label-darkcyan }
 : **11:59PM** ⏰ Due: **Reflection**{: .label .label-yellow }
 : _Begin reading next week’s chapter._
 : _Work through its PAs and CAs._
 
-Saturday - Jul 23
+Saturday<br/>Jul 23
 : _Read next week's chapter (chapter 6) and start in the PAs and CAs_
 
-Sunday - Jul 24
+Sunday<br/>Jul 24
 : _By the end of Sunday: Ideally, you should be finished with PAs for Chapter 6 and done with the CAs for its first 4-5 sections._
 
 

--- a/_modules/week-06.md
+++ b/_modules/week-06.md
@@ -2,32 +2,32 @@
 title: Week 6
 topic: Exploiting self-similarity (Recursion)
 ---
-Monday - Jul 25
+Monday<br/>Jul 25
 : **11:59PM** ⏰  Due: **PA06**{: .label .label-orange }
 : _Finish reading and review Chapter 06 in zyBooks._
 : _Complete the PAs and CAs._
 : _Test your understanding with the Reading Quiz._
 
-Tuesday - Jul 26
+Tuesday<br/>Jul 26
 : **09:30am** **Class**{: .label .label-purple }
 : **11:59PM** ⏰  Due: **CA06**{: .label .label-blue }
 : **11:59PM** ⏰  Due: **LA05**{: .label .label-green }
 
-Wednesday - Jul 27
+Wednesday<br/>Jul 27
 : **09:30am** **Class**{: .label .label-purple }
 : **11:59PM** ⏰  Due: **LA05**{: .label .label-green }
 
-Thursday - Jul 28
+Thursday<br/>Jul 28
 : **09:30am** **Class**{: .label .label-purple }
 : **11:59PM** ⏰  Due: **LA Checkpoint**{: .label .label-green }
 
-Friday - Jul 29
+Friday<br/>Jul 29
 : <p class="text-grey-dk-000 mb-0"><em>Instruction Ends (Session A)</em></p>
 
 : **11:59PM** ⏰  Due: **Final Project**{: .label .label-red }
 
-Saturday - Jul 30
+Saturday<br/>Jul 30
 
-Sunday - Jul 31
+Sunday<br/>Jul 31
 
 


### PR DESCRIPTION
I'm not sure if this is what you were referring regarding the change in the days of the week - it now displays the date consistently underneath the weekday name.